### PR TITLE
docs: add comprehensive OSS marketing strategy

### DIFF
--- a/MARKETING.md
+++ b/MARKETING.md
@@ -1,0 +1,314 @@
+# Tarzan OSS Marketing Strategy
+
+> Comprehensive launch and promotion plan for Tarzan - the email-powered, self-hostable blogging platform.
+
+## Target Audience
+
+| Segment | Description | Priority |
+|---------|-------------|----------|
+| **Self-Hosters** | Privacy-conscious users who run their own infrastructure | High |
+| **Developers/DevOps** | Go/Vue.js developers, Docker/K8s users | High |
+| **Indie Hackers** | Bootstrappers building in public | Medium |
+| **Content Creators** | Bloggers seeking simplicity and ownership | Medium |
+| **Privacy Advocates** | Users escaping vendor lock-in | Medium |
+
+---
+
+## Tier 1: High-Intent Channels (Priority Launch)
+
+These platforms attract users actively seeking solutions like Tarzan. Launch here first for maximum qualified traffic.
+
+### Product Launch Platforms
+
+| Platform | URL | Type | Priority | Notes |
+|----------|-----|------|----------|-------|
+| **Product Hunt** | https://www.producthunt.com | Free | Critical | Schedule launch for Tuesday-Thursday. Prepare assets, hunter, and maker community support |
+| **Hacker News (Show HN)** | https://news.ycombinator.com/showhn.html | Free | Critical | Post as "Show HN: Tarzan – Email-powered blogging with Go/Vue.js". Best times: 6-8am PT weekdays |
+| **Indie Hackers** | https://www.indiehackers.com | Free | High | Post in Products section + write a "building in public" story |
+| **Lobste.rs** | https://lobste.rs | Free (invite-only) | High | Technical audience, curated discussions. Need an invite |
+
+### Self-Hosting Communities (Core Audience)
+
+| Platform | URL | Type | Priority | Notes |
+|----------|-----|------|----------|-------|
+| **r/selfhosted** | https://reddit.com/r/selfhosted | Free | Critical | 500k+ members. Primary target audience. Follow self-promotion rules |
+| **Awesome-Selfhosted** | https://github.com/awesome-selfhosted/awesome-selfhosted | Free (PR) | Critical | Submit PR to add Tarzan under "Blogging Platforms" category |
+| **selfh.st/apps** | https://selfh.st/apps/ | Free | High | Self-hosted app directory |
+| **r/homelab** | https://reddit.com/r/homelab | Free | High | Share deployment guides, Docker Compose setup |
+
+### Developer Communities
+
+| Platform | URL | Type | Priority | Notes |
+|----------|-----|------|----------|-------|
+| **Dev.to** | https://dev.to | Free | Critical | Write technical articles: architecture, Go patterns, Vue.js setup |
+| **Hashnode** | https://hashnode.com | Free | High | Cross-post articles with canonical URLs |
+| **r/golang** | https://reddit.com/r/golang | Free | High | 200k+ subscribers. Focus on Go architecture |
+| **Gophers Slack** | https://gophers.slack.com | Free | High | 50k+ members. Share in #showandtell channel |
+| **Discord Gophers** | https://discord.gg/golang | Free | High | 44k+ members |
+
+---
+
+## Tier 2: Strong Reach Channels
+
+Broader reach platforms with engaged technical audiences.
+
+### Software Directories & Alternatives
+
+| Platform | URL | Type | Priority | Notes |
+|----------|-----|------|----------|-------|
+| **AlternativeTo** | https://alternativeto.net | Free | High | List as alternative to Ghost, WordPress, Substack, Medium |
+| **OpenSourceAlternative.to** | https://opensourcealternative.to | Free | High | OSS-focused directory |
+| **SaaSHub** | https://www.saashub.com | Free | High | DR 75, dofollow backlinks |
+| **Slant** | https://www.slant.co | Free | Medium | Comparison-focused Q&A |
+| **LibHunt** | https://www.libhunt.com | Free | Medium | Tracks mentions on Reddit/HN/dev.to |
+| **StackShare** | https://stackshare.io | Free | Medium | Tech stack showcase |
+
+### Open Source Directories
+
+| Platform | URL | Type | Priority | Notes |
+|----------|-----|------|----------|-------|
+| **GitHub Trending** | https://github.com/trending | Organic | High | Aim for trending through coordinated launch |
+| **Open Hub** | https://openhub.net | Free | Medium | OSS project analytics |
+| **SourceForge** | https://sourceforge.net | Free | Medium | Legacy but still has traffic |
+| **Libraries.io** | https://libraries.io | Automatic | Medium | Auto-indexed from GitHub |
+| **Openbase** | https://openbase.com | Free | Medium | Package comparison with reviews |
+
+### Reddit Communities (Extended)
+
+| Subreddit | Members | Notes |
+|-----------|---------|-------|
+| r/opensource | 150k+ | General OSS discussion |
+| r/webdev | 2M+ | Web development focus |
+| r/docker | 200k+ | Share Docker/Compose setup |
+| r/kubernetes | 300k+ | K8s deployment guides |
+| r/privacy | 1.5M+ | Privacy/data ownership angle |
+| r/vuejs | 50k+ | Vue.js community |
+| r/HomeServer | 100k+ | Home server setups |
+| r/degoogle | 300k+ | Self-hosting, privacy focus |
+| r/DataHoarder | 600k+ | Data ownership audience |
+
+---
+
+## Tier 3: Newsletters & Content Syndication
+
+Reach engaged subscribers through curated newsletters.
+
+### Developer Newsletters
+
+| Newsletter | URL | Audience | Notes |
+|------------|-----|----------|-------|
+| **Golang Weekly** | https://golangweekly.com | 35k+ Go devs | Submit via their submission form |
+| **Changelog Weekly** | https://changelog.com/weekly | OSS enthusiasts | Email submissions accepted |
+| **DevOps Weekly** | https://www.devopsweekly.com | DevOps engineers | CI/CD focus angle |
+| **Console.dev** | https://console.dev | Developers | Weekly tool digest |
+| **Hacker Newsletter** | https://hackernewsletter.com | 60k+ | Curated from HN (organic) |
+| **Docker Weekly** | https://www.docker.com/newsletter | Docker users | Container deployment angle |
+| **KubeWeekly** | https://www.cncf.io/kubeweekly | K8s community | K8s deployment guide |
+| **TLDR Newsletter** | https://tldr.tech | 1.2M+ devs | Submit via their form |
+| **Morning Brew (Sidekick)** | https://www.morningbrew.com | Tech audience | Broader reach |
+
+### Self-Hosting / Privacy Newsletters
+
+| Newsletter | URL | Notes |
+|------------|-----|-------|
+| **Noted (selfh.st)** | https://selfh.st/newsletter | Self-hosting focused |
+| **Privacy Guides Newsletter** | https://www.privacyguides.org | Privacy-focused tools |
+
+---
+
+## Tier 4: Startup & Product Directories
+
+Build backlinks and discoverability through startup directories.
+
+### Free Startup Directories
+
+| Platform | URL | DR | Notes |
+|----------|-----|-----|-------|
+| **BetaList** | https://betalist.com | 73 | Pre-launch/beta products |
+| **Launching Next** | https://launchingnext.com | - | Daily curated list |
+| **Startup Stash** | https://startupstash.com | - | Tools directory |
+| **Starter Story** | https://starterstory.com | - | Startup stories |
+| **MicroLaunch** | https://microlaunch.net | - | Affordable paid option |
+| **Uneed** | https://uneed.best | - | Dofollow links |
+| **Dev Hunt** | https://devhunt.org | - | Developer tools |
+| **Peerlist Launchpad** | https://peerlist.io | - | Week-long launch cycle |
+
+### Investor/Business Directories (Optional)
+
+| Platform | URL | Notes |
+|----------|-----|-------|
+| **Crunchbase** | https://crunchbase.com | Free basic listing |
+| **AngelList** | https://angel.co | Startup profiles |
+| **F6S** | https://f6s.com | Startup resources |
+| **Gust** | https://gust.com | Investor connections |
+
+---
+
+## Tier 5: Niche & Long-Tail Channels
+
+Specialized communities for sustained discovery.
+
+### Privacy-Focused Directories
+
+| Platform | URL | Notes |
+|----------|-----|-------|
+| **PRISM Break** | https://prism-break.org | Privacy software recommendations |
+| **PrivacyTools.io** | https://privacytools.io | Privacy-respecting alternatives |
+| **Privacy Guides** | https://privacyguides.org | Community recommendations |
+| **r/privacytoolsIO** | https://reddit.com/r/privacytoolsIO | Reddit community |
+
+### Blogging/CMS Alternative Directories
+
+| Platform | URL | Notes |
+|----------|-----|-------|
+| **AlternativeTo (Ghost)** | https://alternativeto.net/software/ghost | List as Ghost alternative |
+| **AlternativeTo (WordPress)** | https://alternativeto.net/software/wordpress | List as WP alternative |
+| **AlternativeTo (Substack)** | https://alternativeto.net/software/substack | Email + blog angle |
+| **AlternativeTo (Medium)** | https://alternativeto.net/software/medium | Self-hosted Medium |
+
+### Technology-Specific Communities
+
+| Platform | URL | Audience | Notes |
+|----------|-----|----------|-------|
+| **Vue.js Discord (Vue Land)** | https://discord.gg/vue | Vue devs | Share in showcase channel |
+| **Vue Forum** | https://forum.vuejs.org | Vue devs | Official forum |
+| **Go Forum** | https://forum.golangbridge.org | Go devs | GolangBridge community |
+| **Echo.js** | https://echojs.com | JS/Frontend devs | Submit frontend aspects |
+| **Made with Vue.js** | https://madewithvuejs.com | Vue showcase | Project showcase |
+
+### Cloud Native / Kubernetes
+
+| Platform | URL | Notes |
+|----------|-----|-------|
+| **Artifact Hub** | https://artifacthub.io | Helm chart listing (if applicable) |
+| **CNCF Landscape** | https://landscape.cncf.io | Cloud native tools (aspirational) |
+
+---
+
+## Tier 6: Social Media (Your Owned Channels)
+
+Leverage for announcements and community building.
+
+| Platform | Strategy |
+|----------|----------|
+| **LinkedIn** | Professional audience, technical posts, architecture articles |
+| **X/Twitter** | Developer community, #buildinpublic, #golang, #vuejs hashtags |
+| **Threads** | Cross-post from X |
+| **Bluesky** | Tech-forward early adopters |
+| **Mastodon** | fosstodon.org or similar tech instance |
+| **Buy Me a Coffee** | Supporter updates |
+| **Patreon** | Exclusive updates for supporters |
+| **GitHub Sponsors** | Already configured - promote in README |
+
+---
+
+## Tier 7: Podcasts & Media (Earned Media)
+
+Reach out for interview opportunities.
+
+| Podcast | URL | Notes |
+|---------|-----|-------|
+| **The Changelog** | https://changelog.com/podcast | Premier OSS podcast |
+| **Go Time** | https://changelog.com/gotime | Go-specific podcast |
+| **Indie Hackers Podcast** | https://indiehackers.com/podcast | Bootstrapping stories |
+| **Syntax FM** | https://syntax.fm | Web dev focus |
+| **Full Stack Radio** | https://fullstackradio.com | Adam Wathan (TailwindCSS creator) |
+| **Hanselminutes** | https://hanselminutes.com | Developer interviews |
+| **Software Engineering Daily** | https://softwareengineeringdaily.com | Technical deep dives |
+| **Self-Hosted Podcast** | https://selfhosted.show | Jupiter Broadcasting |
+| **Linux Unplugged** | https://linuxunplugged.com | Self-hosting audience |
+
+---
+
+## Launch Execution Plan
+
+### Phase 1: Pre-Launch (1-2 weeks before)
+
+- [ ] Prepare all assets (logo, screenshots, GIFs, demo video)
+- [ ] Write launch copy variations for different platforms
+- [ ] Create accounts on all target platforms
+- [ ] Line up a Product Hunt hunter (optional but helpful)
+- [ ] Prepare technical blog posts for dev.to/Hashnode
+- [ ] Submit PR to awesome-selfhosted (can take time to merge)
+- [ ] Build anticipation on social media
+
+### Phase 2: Launch Day
+
+**Morning (6-8am PT):**
+- [ ] Post to Hacker News (Show HN)
+- [ ] Launch on Product Hunt
+- [ ] Post to r/selfhosted
+- [ ] Announce on social media channels
+
+**Throughout the day:**
+- [ ] Engage with all comments and feedback
+- [ ] Cross-post to r/golang, r/opensource
+- [ ] Share in Gophers Slack/Discord
+
+### Phase 3: Launch Week
+
+- [ ] Publish technical articles on dev.to, Hashnode
+- [ ] Submit to newsletters (Golang Weekly, etc.)
+- [ ] Post to remaining Reddit communities
+- [ ] Submit to software directories (AlternativeTo, SaaSHub)
+- [ ] Share on Vue.js communities
+
+### Phase 4: Ongoing (Post-Launch)
+
+- [ ] Submit to startup directories
+- [ ] Continue content marketing
+- [ ] Reach out to podcasts
+- [ ] Monitor and respond to community feedback
+- [ ] Submit to privacy-focused directories
+- [ ] Apply to be listed on PRISM Break / PrivacyTools
+
+---
+
+## Content Ideas for Technical Articles
+
+1. **"Building an Email-Powered Blog in Go"** - Architecture deep-dive
+2. **"Why I Chose SQLite for a Self-Hosted Blogging Platform"** - Database decisions
+3. **"Embedding Vue.js in a Go Binary"** - Technical implementation
+4. **"From Email to Blog Post: How Postmark Webhooks Power Tarzan"** - Integration guide
+5. **"Self-Hosting vs. SaaS: Why Data Ownership Matters"** - Philosophy piece
+6. **"12-Factor App Design for Self-Hosted Software"** - Best practices
+7. **"Zero-Downtime Kubernetes Deployment for Bloggers"** - K8s guide
+
+---
+
+## Messaging Angles by Audience
+
+| Audience | Primary Message |
+|----------|-----------------|
+| **Self-Hosters** | "Own your blog, own your data. Single binary, zero dependencies." |
+| **Go Developers** | "Clean Go architecture with embedded Vue.js SPA. Batteries included." |
+| **Privacy Advocates** | "No vendor lock-in. Air-gap compatible. Your content, your rules." |
+| **Indie Hackers** | "Ship your blog by sending an email. Focus on content, not infrastructure." |
+| **Bloggers** | "The simplest way to blog: send an email, get a beautiful post." |
+
+---
+
+## Tracking & Metrics
+
+Track submissions and results:
+
+| Platform | Submitted | Date | Result | Notes |
+|----------|-----------|------|--------|-------|
+| Product Hunt | [ ] | - | - | - |
+| Hacker News | [ ] | - | - | - |
+| r/selfhosted | [ ] | - | - | - |
+| Awesome-Selfhosted PR | [ ] | - | - | - |
+| ... | ... | ... | ... | ... |
+
+---
+
+## Resources
+
+- [LaunchDirectories.com](https://launchdirectories.com/) - 100+ startup directories database
+- [Awesome Newsletters](https://github.com/zudochkin/awesome-newsletters) - Curated newsletter list
+- [Developer Newsletters](https://github.com/jackbridger/developer-newsletters) - Newsletter sponsorship info
+- [LeadWave SaaS Directories](https://getleadwave.io/list-of-saas-directories) - 170+ SaaS directories
+
+---
+
+*Last updated: December 2024*

--- a/MARKETING.md
+++ b/MARKETING.md
@@ -311,4 +311,3 @@ Track submissions and results:
 
 ---
 
-*Last updated: December 2024*


### PR DESCRIPTION
Add MARKETING.md with tiered launch plan covering:
- Product launch platforms (Product Hunt, Hacker News, Indie Hackers)
- Self-hosting communities (r/selfhosted, awesome-selfhosted)
- Developer communities (dev.to, Go/Vue.js channels)
- Software directories (AlternativeTo, SaaSHub)
- Newsletters (Golang Weekly, Changelog)
- Privacy-focused directories (PRISM Break, PrivacyTools)
- Podcast outreach opportunities
- Execution timeline and content ideas